### PR TITLE
Align Client.application_logs to yarn cli

### DIFF
--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -318,6 +318,7 @@ message QueuesResponse {
 message LogsRequest {
   string id = 1;
   string user = 2;
+  string owner = 3;
 }
 
 

--- a/skein/core.py
+++ b/skein/core.py
@@ -794,13 +794,17 @@ class Client(_ClientBase):
         resp = self._call('getStatus', proto.Application(id=app_id))
         return ApplicationReport.from_protobuf(resp)
 
-    def application_logs(self, app_id, user=""):
+    def application_logs(self, app_id, owner="", user=""):
         """Get logs from a completed skein application.
 
         Parameters
         ----------
         app_id : str
             The id of the application.
+        owner : str, optional
+            The owner of the application. If not specified it will be
+            the user from yarn's application report or if not found
+            the current logged user.
         user : str, optional
             The user to get the application logs as. Requires the current user
             to have permissions to proxy as ``user``. Default is the current
@@ -816,7 +820,7 @@ class Client(_ClientBase):
         >>> client.application_logs('application_1526134340424_0012')
         ApplicationLogs<application_1526134340424_0012>
         """
-        resp = self._call('getLogs', proto.LogsRequest(id=app_id, user=user))
+        resp = self._call('getLogs', proto.LogsRequest(id=app_id, user=user, owner=owner))
         return ApplicationLogs(app_id, dict(resp.logs))
 
     def move_application(self, app_id, queue):


### PR DESCRIPTION
- make owner injectable from python
- if ApplicationReport fails use the current user as owner of the application, this happens when the application is removed from RM (after some minutes in our case)

https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java#L1218